### PR TITLE
Fix the C2 loopback IP address in lb/1-ebgp exercise

### DIFF
--- a/docs/lb/1-ebgp.md
+++ b/docs/lb/1-ebgp.md
@@ -18,7 +18,7 @@ The routers in your lab use the following BGP AS numbers. C2 and P1 advertise an
 | **AS65000** ||
 | rtr | 10.0.0.1 |  |
 | **AS65001** ||
-| c2 | 10.7.5.0 | 10.7.5.0/24 |
+| c2 | 10.7.5.1 | 10.7.5.0/24 |
 | **AS65100** ||
 | p1 | 10.0.0.2 | 10.1.3.0/24 |
 | p2 | 10.0.0.3 |  |
@@ -124,7 +124,7 @@ The following information might help you if you plan to build custom lab infrast
 | Ethernet1 | 10.1.0.2/30 |  | rtr -> p1 |
 | Ethernet2 | 10.1.0.6/30 |  | rtr -> p2 |
 | Ethernet3 | 10.1.0.10/30 |  | rtr -> p3 |
-| **c2** |  10.7.5.0/24 |  | Loopback |
+| **c2** |  10.7.5.1/24 |  | Loopback |
 | swp1 | 10.1.0.17/30 |  | c2 -> p2 |
 | swp2 | 10.1.0.21/30 |  | c2 -> p3 |
 | **p1** |  10.0.0.2/32 |  | Loopback |

--- a/lb/1-ebgp/topology.yml
+++ b/lb/1-ebgp/topology.yml
@@ -26,7 +26,7 @@ nodes:
   c2:
     bgp.as: 65001
     bgp.advertise_loopback: true
-    loopback.ipv4: 10.7.5.0/24
+    loopback.ipv4: 10.7.5.1/24
 
 links: [ rtr-p1, rtr-p2, rtr-p3, p1-p2, p2-c2, p3-c2 ]
 


### PR DESCRIPTION
The loopback address had all-zeroes in the host bits. That did not bother FRRouting, but started to bother netlab once we implemented stricter checks on loopback IP addresses.

Closes #30